### PR TITLE
Add new events for cursor component, multiple bugs fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Sublime text project files
+*.sublime-workspace
+*.sublime-project

--- a/cursor-target.js
+++ b/cursor-target.js
@@ -1,8 +1,11 @@
 /**
- * Click/hover target for [cursor](#cursor).
+ * Click/hover/move/button target for [cursor](#cursor).
  *
- * To trigger code when clicking or hovering, use `.addHoverFunction(f)`,
- * `.addUnHoverFunction(f)` and `.addClickFunction(f)` with any `function f() {}`.
+ * To trigger code when clicking, hovering, unhovering, moving cursor, pressing
+ * cursor button or releasing cursor button, use `.addClickFunction(f)`,
+ * `.addHoverFunction(f)`, `.addUnHoverFunction(f)`,
+ * `.addCursorMoveFunction(f)`, `.addCursorDownFunction(f)` and
+ * `.addCursorUpFunction(f)` respectively with any `function f() {}`.
  *
  * To call members on a different component, you can set up a cursor target like
  * so:
@@ -29,6 +32,15 @@
  *
  * addClickFunction(callback);
  * removeClickFunction(callback);
+ *
+ * addCursorMoveFunction(callback);
+ * removeCursorMoveFunction(callback);
+ *
+ * addCursorDownFunction(callback);
+ * removeCursorDownFunction(callback);
+ *
+ * addCursorUpFunction(callback);
+ * removeCursorUpFunction(callback);
  * ```
  *
  * **Requirements:**
@@ -42,6 +54,9 @@ WL.registerComponent("cursor-target", {
       this.hoverFunctions = [];
       this.unHoverFunctions = [];
       this.clickFunctions = [];
+      this.cursorMoveFunctions = [];
+      this.cursorDownFunctions = [];
+      this.cursorUpFunctions = [];
     },
     onHover: function(object, cursor) {
         for(let i in this.hoverFunctions) {
@@ -58,53 +73,80 @@ WL.registerComponent("cursor-target", {
             this.clickFunctions[i](object, cursor);
         }
     },
-    addHoverFunction: function(f) {
-        if(typeof f !== "function") {
-            throw new TypeError(this.object.name
-                + ".cursor-target: Argument needs to be a function");
+    onCursorMove: function(object, cursor) {
+        for(let i in this.cursorMoveFunctions) {
+            this.cursorMoveFunctions[i](object, cursor);
         }
+    },
+    onCursorDown: function(object, cursor) {
+        for(let i in this.cursorDownFunctions) {
+            this.cursorDownFunctions[i](object, cursor);
+        }
+    },
+    onCursorUp: function(object, cursor) {
+        for(let i in this.cursorUpFunctions) {
+            this.cursorUpFunctions[i](object, cursor);
+        }
+    },
+    addHoverFunction: function(f) {
+        this._validateCallback(f);
         this.hoverFunctions.push(f);
     },
     removeHoverFunction: function(f) {
-        if(typeof f !== "function") {
-            throw new TypeError(this.object.name
-                + ".cursor-target: Argument needs to be a function");
-        }
+        this._validateCallback(f);
         this._removeItemOnce(this.hoverFunctions, f);
     },
     addUnHoverFunction: function(f) {
-        if(typeof f !== "function") {
-            throw new TypeError(this.object.name
-                + ".cursor-target: Argument needs to be a function");
-        }
+        this._validateCallback(f);
         this.unHoverFunctions.push(f);
     },
     removeUnHoverFunction: function(f) {
-        if(typeof f !== "function") {
-            throw new TypeError(this.object.name
-                + ".cursor-target: Argument needs to be a function");
-        }
+        this._validateCallback(f);
         this._removeItemOnce(this.unHoverFunctions, f);
     },
     addClickFunction: function(f) {
-        if(typeof f !== "function") {
-            throw new TypeError(this.object.name
-                + ".cursor-target: Argument needs to be a function");
-        }
+        this._validateCallback(f);
         this.clickFunctions.push(f);
     },
     removeClickFunction: function(f) {
-        if(typeof f !== "function") {
-            throw new TypeError(this.object.name
-                + ".cursor-target: Argument needs to be a function");
-        }
+        this._validateCallback(f);
         this._removeItemOnce(this.clickFunctions, f);
+    },
+    addCursorMoveFunction: function(f) {
+        this._validateCallback(f);
+        this.cursorMoveFunctions.push(f);
+    },
+    removeCursorMoveFunction: function(f) {
+        this._validateCallback(f);
+        this._removeItemOnce(this.cursorMoveFunctions, f);
+    },
+    addCursorDownFunction: function(f) {
+        this._validateCallback(f);
+        this.cursorDownFunctions.push(f);
+    },
+    removeCursorDownFunction: function(f) {
+        this._validateCallback(f);
+        this._removeItemOnce(this.cursorDownFunctions, f);
+    },
+    addCursorUpFunction: function(f) {
+        this._validateCallback(f);
+        this.cursorUpFunctions.push(f);
+    },
+    removeCursorUpFunction: function(f) {
+        this._validateCallback(f);
+        this._removeItemOnce(this.cursorUpFunctions, f);
     },
 
     _removeItemOnce: function(arr, value) {
         var index = arr.indexOf(value);
         if(index > -1) arr.splice(index, 1);
         return arr;
-    }
+    },
+    _validateCallback: function(f) {
+        if(typeof f !== "function") {
+            throw new TypeError(this.object.name
+                + ".cursor-target: Argument needs to be a function");
+        }
+    },
 });
 

--- a/cursor.js
+++ b/cursor.js
@@ -27,6 +27,8 @@ WL.registerComponent('cursor', {
     handedness: {type: WL.Type.Enum, values: ['input component', 'left', 'right', 'none'], default: 'input component'},
     /** Mode for raycasting, whether to use PhysX or simple collision components */
     rayCastMode: {type: WL.Type.Enum, values: ['collision', 'physx'], default: 'collision'},
+    /** (optional) Should cursor style be changed when hovering? */
+    styleCursor: {type: WL.Type.Bool, default: true},
   }, {
     init: function() {
         /* VR session cache, in case in VR */
@@ -176,23 +178,26 @@ WL.registerComponent('cursor', {
             if(!this.hoveringObject || !this.hoveringObject.equals(rayHit.objects[0])) {
                 /* Unhover previous, if exists */
                 if(this.hoveringObject) {
-                    let cursorTarget = this.hoveringObject.getComponent("cursor-target");
+                    const cursorTarget = this.hoveringObject.getComponent("cursor-target");
                     if(cursorTarget) cursorTarget.onUnhover(this.hoveringObject, this);
                     this.globalTarget.onUnhover(this.hoveringObject, this);
                 }
 
                 /* Hover new object */
                 this.hoveringObject = rayHit.objects[0];
-                WL.canvas.style.cursor = "pointer";
-                let cursorTarget = this.hoveringObject.getComponent("cursor-target");
+                if(this.styleCursor)
+                    WL.canvas.style.cursor = "pointer";
+                const cursorTarget = this.hoveringObject.getComponent("cursor-target");
                 if(cursorTarget) cursorTarget.onHover(this.hoveringObject, this);
                 this.globalTarget.onHover(this.hoveringObject, this);
             }
         } else if(this.hoveringObject && rayHit.hitCount == 0) {
-            let cursorTarget = this.hoveringObject.getComponent("cursor-target");
+            const cursorTarget = this.hoveringObject.getComponent("cursor-target");
             if(cursorTarget) cursorTarget.onUnhover(this.hoveringObject, this);
             this.globalTarget.onUnhover(this.hoveringObject, this);
             this.hoveringObject = null;
+            if(this.styleCursor)
+                WL.canvas.style.cursor = "default";
         }
     },
 

--- a/cursor.js
+++ b/cursor.js
@@ -241,6 +241,9 @@ WL.registerComponent('cursor', {
         s.addEventListener('select', this.onSelect.bind(this));
         s.addEventListener('selectstart', this.onSelectStart.bind(this));
         s.addEventListener('selectend', this.onSelectEnd.bind(this));
+
+        /* After AR session was entered, the projection matrix changed */
+        this.onViewportResize();
     },
 
     /** 'select' event listener */
@@ -252,8 +255,6 @@ WL.registerComponent('cursor', {
     /** 'selectstart' event listener */
     onSelectStart: function(e) {
         this.arTouchDown = true;
-        /* After AR session was entered, the projection matrix changed */
-        this.onViewportResize();
         if(e.inputSource.handedness == this.handedness) this.isDown = true;
     },
 

--- a/cursor.js
+++ b/cursor.js
@@ -2,8 +2,9 @@ import {vec3, mat4} from 'gl-matrix';
 /**
  * 3D cursor for desktop/mobile/VR.
  *
- * Implements a ray-casting cursor into the scene. To react to clicking/hover/unhover
- * use a [cursor-target](#cursor-target).
+ * Implements a ray-casting cursor into the scene. To react to
+ * clicking/hover/unhover/cursor down/cursor up/move use a
+ * [cursor-target](#cursor-target).
  *
  * For VR, the ray is cast in direction of
  * [this.object.getForward()](/jsapi/object/#getforward). For desktop and mobile, the
@@ -62,7 +63,9 @@ WL.registerComponent('cursor', {
          * otherwise just use the objects transformation */
         if(this.viewComponent != null) {
             WL.canvas.addEventListener("click", this.onClick.bind(this));
-            WL.canvas.addEventListener("mousemove", this.onMouseMove.bind(this));
+            WL.canvas.addEventListener("pointermove", this.onPointerMove.bind(this));
+            WL.canvas.addEventListener("pointerdown", this.onPointerDown.bind(this));
+            WL.canvas.addEventListener("pointerup", this.onPointerUp.bind(this));
 
             this.projectionMatrix = new Float32Array(16);
             mat4.invert(this.projectionMatrix, this.viewComponent.projectionMatrix);
@@ -70,6 +73,8 @@ WL.registerComponent('cursor', {
         }
         this.isHovering = false;
         this.visible = true;
+        this.isDown = false;
+        this.lastIsDown = false;
 
         this.cursorPos = new Float32Array(3);
         this.hoveringObject = null;
@@ -95,25 +100,10 @@ WL.registerComponent('cursor', {
          * projection matrix because of the aspect ratio. */
         mat4.invert(this.projectionMatrix, this.viewComponent.projectionMatrix);
     },
-    /** 'click' event listener */
-    onClick: function(e) {
-        let bounds = e.target.getBoundingClientRect();
-        let rayHit = this.updateMousePos(e.clientX, e.clientY, bounds.width, bounds.height);
-        if(rayHit.hitCount > 0) {
-            let o = rayHit.objects[0];
-            this._clickOn(o);
-        }
-    },
-    /** Click on given object, which executes the cursor-target onClick callbacks */
-    _clickOn: function(o) {
-        let cursorTarget = o.getComponent("cursor-target", 0);
-        if(cursorTarget) cursorTarget.onClick(o, this);
-        this.globalTarget.onClick(o, this);
-    },
 
     _setCursorRayTransform: function(hitPosition) {
         if(!this.cursorRayObject) return;
-        let dist = vec3.dist(this.origin, hitPosition);
+        const dist = vec3.dist(this.origin, hitPosition);
         this.cursorRayObject.setTranslationLocal([0.0, 0.0, -dist / 2]);
         if(this.cursorRayScalingAxis != 4) {
             this.cursorRayObject.resetScaling();
@@ -138,6 +128,10 @@ WL.registerComponent('cursor', {
     },
 
     update: function() {
+        this.doUpdate(false);
+    },
+
+    doUpdate: function(doClick) {
         /* If in VR, set the cursor ray based on object transform */
         if(this.session) {
             if(this.arTouchDown && this.input && WL.xrSession.inputSources[0].handedness === 'none') {
@@ -149,7 +143,7 @@ WL.registerComponent('cursor', {
                 this.object.getTranslationWorld(this.origin);
                 this.object.getForward(this.direction);
             }
-            let rayHit = this.rayHit = (this.rayCastMode == 0) ?
+            const rayHit = this.rayHit = (this.rayCastMode == 0) ?
                 WL.scene.rayCast(this.origin, this.direction, this.collisionMask) :
                 WL.physics.rayCast(this.origin, this.direction, this.collisionMask, this.maxDistance);
 
@@ -159,7 +153,7 @@ WL.registerComponent('cursor', {
                 this.cursorPos.fill(0);
             }
 
-            this.hoverBehaviour(rayHit);
+            this.hoverBehaviour(rayHit, doClick);
         }
 
         if(this.cursorObject) {
@@ -173,9 +167,14 @@ WL.registerComponent('cursor', {
         }
     },
 
-    hoverBehaviour: function(rayHit) {
+    hoverBehaviour: function(rayHit, doClick) {
         if(rayHit.hitCount > 0) {
-            if(!this.hoveringObject || !this.hoveringObject.equals(rayHit.objects[0])) {
+            if(this.hoveringObject && this.hoveringObject.equals(rayHit.objects[0])) {
+                const cursorTarget = this.hoveringObject.getComponent("cursor-target");
+                if(cursorTarget) cursorTarget.onCursorMove(this.hoveringObject, this);
+                this.globalTarget.onCursorMove(this.hoveringObject, this);
+            }
+            else if(!this.hoveringObject || !this.hoveringObject.equals(rayHit.objects[0])) {
                 /* Unhover previous, if exists */
                 if(this.hoveringObject) {
                     const cursorTarget = this.hoveringObject.getComponent("cursor-target");
@@ -185,11 +184,31 @@ WL.registerComponent('cursor', {
 
                 /* Hover new object */
                 this.hoveringObject = rayHit.objects[0];
-                if(this.styleCursor)
-                    WL.canvas.style.cursor = "pointer";
+                if(this.styleCursor) WL.canvas.style.cursor = "pointer";
                 const cursorTarget = this.hoveringObject.getComponent("cursor-target");
                 if(cursorTarget) cursorTarget.onHover(this.hoveringObject, this);
                 this.globalTarget.onHover(this.hoveringObject, this);
+            }
+
+            /* Cursor up/down */
+            const cursorTarget = this.hoveringObject.getComponent("cursor-target");
+            if(this.isDown !== this.lastIsDown) {
+                if(this.isDown) {
+                    /* Down */
+                    if(cursorTarget) cursorTarget.onCursorDown(this.hoveringObject, this);
+                    this.globalTarget.onCursorDown(this.hoveringObject, this);
+                }
+                else {
+                    /* Up */
+                    if(cursorTarget) cursorTarget.onCursorUp(this.hoveringObject, this);
+                    this.globalTarget.onCursorUp(this.hoveringObject, this);
+                }
+            }
+
+            /* Click */
+            if(doClick) {
+                if(cursorTarget) cursorTarget.onClick(this.hoveringObject, this);
+                this.globalTarget.onClick(this.hoveringObject, this);
             }
         } else if(this.hoveringObject && rayHit.hitCount == 0) {
             const cursorTarget = this.hoveringObject.getComponent("cursor-target");
@@ -199,6 +218,8 @@ WL.registerComponent('cursor', {
             if(this.styleCursor)
                 WL.canvas.style.cursor = "default";
         }
+
+        this.lastIsDown = this.isDown;
     },
 
     /**
@@ -217,31 +238,68 @@ WL.registerComponent('cursor', {
             this.session = null;
         }.bind(this));
 
-        s.addEventListener('select', function(e) {
-            if(e.inputSource.handedness != this.handedness) return;
-            if(this.hoveringObject) {
-                this._clickOn(this.hoveringObject);
-            }
-        }.bind(this));
-
-        s.addEventListener('selectstart', this.onTouchStart.bind(this));
-        s.addEventListener('selectend', this.onTouchEnd.bind(this));
+        s.addEventListener('select', this.onSelect.bind(this));
+        s.addEventListener('selectstart', this.onSelectStart.bind(this));
+        s.addEventListener('selectend', this.onSelectEnd.bind(this));
     },
-    onTouchStart: function(e) {
+
+    /** 'select' event listener */
+    onSelect: function(e) {
+        if(e.inputSource.handedness != this.handedness) return;
+        this.doUpdate(true);
+    },
+
+    /** 'selectstart' event listener */
+    onSelectStart: function(e) {
         this.arTouchDown = true;
         /* After AR session was entered, the projection matrix changed */
         this.onViewportResize();
+        if(e.inputSource.handedness == this.handedness) this.isDown = true;
     },
-    onTouchEnd: function(e) {
+
+    /** 'selectend' event listener */
+    onSelectEnd: function(e) {
         this.arTouchDown = false;
+        if(e.inputSource.handedness == this.handedness) this.isDown = false;
     },
 
-    /** 'mousemove' event listener */
-    onMouseMove: function (e) {
-        let bounds = e.target.getBoundingClientRect();
-        let rayHit = this.updateMousePos(e.clientX, e.clientY, bounds.width, bounds.height);
+    /** 'pointermove' event listener */
+    onPointerMove: function (e) {
+        /* Don't care about secondary pointers */
+        if(!e.isPrimary) return;
+        const bounds = e.target.getBoundingClientRect();
+        const rayHit = this.updateMousePos(e.clientX, e.clientY, bounds.width, bounds.height);
 
-        this.hoverBehaviour(rayHit);
+        this.hoverBehaviour(rayHit, false);
+    },
+
+    /** 'click' event listener */
+    onClick: function (e) {
+        const bounds = e.target.getBoundingClientRect();
+        const rayHit = this.updateMousePos(e.clientX, e.clientY, bounds.width, bounds.height);
+        this.hoverBehaviour(rayHit, true);
+    },
+
+    /** 'pointerdown' event listener */
+    onPointerDown: function (e) {
+        /* Don't care about secondary pointers or non-left clicks */
+        if(!e.isPrimary || e.button !== 0) return;
+        const bounds = e.target.getBoundingClientRect();
+        const rayHit = this.updateMousePos(e.clientX, e.clientY, bounds.width, bounds.height);
+        this.isDown = true;
+
+        this.hoverBehaviour(rayHit, false);
+    },
+
+    /** 'pointerup' event listener */
+    onPointerUp: function (e) {
+        /* Don't care about secondary pointers or non-left clicks */
+        if(!e.isPrimary || e.button !== 0) return;
+        const bounds = e.target.getBoundingClientRect();
+        const rayHit = this.updateMousePos(e.clientX, e.clientY, bounds.width, bounds.height);
+        this.isDown = false;
+
+        this.hoverBehaviour(rayHit, false);
     },
 
     /**
@@ -250,8 +308,8 @@ WL.registerComponent('cursor', {
      */
     updateMousePos: function(clientX, clientY, w, h) {
         /* Get direction in normalized device coordinate space from mouse position */
-        let left = clientX/w;
-        let top = clientY/h;
+        const left = clientX/w;
+        const top = clientY/h;
         this.direction = [left*2 - 1, -top*2 + 1, -1.0];
         return this.updateDirection();
     },
@@ -264,7 +322,7 @@ WL.registerComponent('cursor', {
             this.projectionMatrix);
         vec3.normalize(this.direction, this.direction);
         vec3.transformQuat(this.direction, this.direction, this.object.transformWorld);
-        let rayHit = this.rayHit = (this.rayCastMode == 0) ?
+        const rayHit = this.rayHit = (this.rayCastMode == 0) ?
             WL.scene.rayCast(this.origin, this.direction, this.collisionMask) :
             WL.physics.rayCast(this.origin, this.direction, this.collisionMask, this.maxDistance);
 
@@ -289,5 +347,5 @@ WL.registerComponent('cursor', {
 
     onActivate: function() {
         this._setCursorVisibility(true);
-    }
+    },
 });

--- a/cursor.js
+++ b/cursor.js
@@ -69,7 +69,7 @@ WL.registerComponent('cursor', {
 
             this.projectionMatrix = new Float32Array(16);
             mat4.invert(this.projectionMatrix, this.viewComponent.projectionMatrix);
-            WL.canvas.addEventListener("resize", this.onViewportResize.bind(this));
+            window.addEventListener("resize", this.onViewportResize.bind(this));
         }
         this.isHovering = false;
         this.visible = true;

--- a/mouse-look.js
+++ b/mouse-look.js
@@ -21,7 +21,7 @@ WL.registerComponent('mouse-look', {
         this.origin = new Float32Array(3);
         this.parentOrigin = new Float32Array(3);
         document.addEventListener('mousemove', function(e) {
-            if(this.mouseDown || !this.requireMouseDown) {
+            if(this.active && (this.mouseDown || !this.requireMouseDown)) {
                 this.rotationY = -this.sensitity*e.movementX/100;
                 this.rotationX = -this.sensitity*e.movementY/100;
 


### PR DESCRIPTION
- Fixed cursor style not being updated after unhovering
- Fixed projection matrix being updated when pressing XR controller button instead of when entering XR session
- Fixed projection matrix not being updated on resize due to listening for resize event in canvas instead of window (HTML elements don't dispatch resize events, only window)
- Let users disable cursor styling on hover
- Add onCursorMove, onCursorDown and onCursorUp. Works for both mouse or XR controllers
- Use pointer events instead of mouse events for better mobile support
- Fixed mouse-look moving camera even when the component is deactivated