### PR TITLE
Add a parameter to restrict movement on the Y axis

### DIFF
--- a/wasd-controls.js
+++ b/wasd-controls.js
@@ -6,7 +6,9 @@ WL.registerComponent('wasd-controls', {
     /** Movement speed in m/s. */
     speed: { type: WL.Type.Float, default: 0.1 },
     /** Object of which the orientation is used to determine forward direction */
-    headObject: { type: WL.Type.Object }
+    headObject: { type: WL.Type.Object },
+    /** Whether or not to restrict movement on the Y axis */
+    restrictY: { type: WL.Type.Bool, default: false }
 }, {
     init: function() {
         this.up = false;
@@ -34,6 +36,7 @@ WL.registerComponent('wasd-controls', {
         direction[0] *= this.speed;
         direction[2] *= this.speed;
         vec3.transformQuat(direction, direction, this.headObject.transformWorld);
+        if (this.restrictY) direction[1] = 0;
         this.object.translate(direction);
     },
 


### PR DESCRIPTION
I realized very quickly that the wasd-controls component doesn't give you any way to toggle movement on the Y axis, which I feel would be a very common use case when someone wants to let the player navigate around a room on desktop solely on the XZ plane. This just adds a simple bool param that will zero out the Y component after transforming direction if it's checked.