### PR TITLE
Move player-height component to its own file

### DIFF
--- a/player-height.js
+++ b/player-height.js
@@ -1,0 +1,26 @@
+WL.registerComponent('player-height', {
+    height: { type: WL.Type.Float, default: 1.75 }
+}, {
+    init: function() {
+        WL.onXRSessionStart.push(this.onXRSessionStart.bind(this));
+        WL.onXRSessionEnd.push(this.onXRSessionEnd.bind(this));
+    },
+
+    start: function() {
+        this.object.resetTranslationRotation();
+        this.object.translate([0.0, this.height, 0.0]);
+    },
+
+    onXRSessionStart: function() {
+        if(!['local', 'viewer'].includes(WebXR.refSpace)) {
+            this.object.resetTranslationRotation();
+        }
+    },
+
+    onXRSessionEnd: function() {
+        if(!['local', 'viewer'].includes(WebXR.refSpace)) {
+            this.object.resetTranslationRotation();
+            this.object.translate([0.0, this.height, 0.0]);
+        }
+    }
+});

--- a/teleport.js
+++ b/teleport.js
@@ -245,30 +245,3 @@ WL.registerComponent('teleport', {
         this.camRoot.setTranslationWorld(p);
     },
 });
-
-WL.registerComponent('player-height', {
-    height: { type: WL.Type.Float, default: 1.75 }
-}, {
-    init: function() {
-        WL.onXRSessionStart.push(this.onXRSessionStart.bind(this));
-        WL.onXRSessionEnd.push(this.onXRSessionEnd.bind(this));
-    },
-
-    start: function() {
-        this.object.resetTranslationRotation();
-        this.object.translate([0.0, this.height, 0.0]);
-    },
-
-    onXRSessionStart: function() {
-        if(!['local', 'viewer'].includes(WebXR.refSpace)) {
-            this.object.resetTranslationRotation();
-        }
-    },
-
-    onXRSessionEnd: function() {
-        if(!['local', 'viewer'].includes(WebXR.refSpace)) {
-            this.object.resetTranslationRotation();
-            this.object.translate([0.0, this.height, 0.0]);
-        }
-    }
-});


### PR DESCRIPTION
I believe it's better and more useful to have both teleport and player-height components in separate files. Using a custom teleport, or no teleport is a valid option. In that case, the player-height component stays useful.