### PR TITLE
trail: Fix incorrect Mesh constructor call

### DIFF
--- a/trail.js
+++ b/trail.js
@@ -64,7 +64,7 @@ export class Trail extends Component {
                 .set([i + 1, i + 0, i + 2, i + 2, i + 3, i + 1]);
         }
 
-        this.mesh = new Mesh({
+        this.mesh = new Mesh(this.engine, {
             vertexCount: vertexCount,
             indexData: this.indexData,
             indexType: MeshIndexType.UnsignedInt,


### PR DESCRIPTION
The constructor of `Mesh` expects the engine as its first argument. The `trail` component instead passed the `MeshParameters` as the only argument. Interestingly enough this doesn't cause any issues during construction, but results in errors when invoking methods on the resulting `Mesh` that try to call into the engine.