### PR TITLE
Add getting and setting position to orbital camera.

### DIFF
--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -57,3 +57,7 @@ export function setFirstMaterialTexture(
 export function deg2rad(value:number){
     return value * Math.PI / 180.0;
 }
+
+export function rad2deg(value: number) {
+    return (value * 180.0) / Math.PI;
+}


### PR DESCRIPTION
Add two methods to orbital camera:
- *getClosestPosition*. Gets a position and rotation (towards origin) based on a provided position on the orbit sphere of the camera.
- *setPosition*. Sets the position of the orbital camera on the sphere. 

Fix issue where camera keeps moving if moving of mouse/touch stops. 