### PR TITLE
Add getting and setting position to orbital camera.

### DIFF
--- a/orbital-camera.ts
+++ b/orbital-camera.ts
@@ -103,7 +103,7 @@ export class OrbitalCamera extends Component {
         canvas.removeEventListener('touchmove', this._onTouchMove);
         canvas.removeEventListener('touchend', this._onTouchEnd);
 
-        /** Reset state to make sure nothing gets stuck */
+        /* Reset state to make sure nothing gets stuck */
         this._mouseDown = false;
         this._initialPinchDistance = 0;
         this._touchStartX = 0;
@@ -114,22 +114,22 @@ export class OrbitalCamera extends Component {
     }
 
     update(): void {
-        /** Always apply damping, because there's no event for stop moving */
+        /* Always apply damping, because there's no event for stop moving */
         this._azimuthSpeed *= this.damping;
         this._polarSpeed *= this.damping;
 
-        /** Stop completely if the speed is very low to avoid endless tiny movements */
+        /* Stop completely if the speed is very low to avoid endless tiny movements */
         if (Math.abs(this._azimuthSpeed) < 0.01) this._azimuthSpeed = 0;
         if (Math.abs(this._polarSpeed) < 0.01) this._polarSpeed = 0;
 
-        /** Apply the speed to the camera angles */
+        /* Apply the speed to the camera angles */
         this._azimuth += this._azimuthSpeed;
         this._polar += this._polarSpeed;
 
-        /** Clamp the polar angle */
+        /* Clamp the polar angle */
         this._polar = Math.min(this.maxElevation, Math.max(this.minElevation, this._polar));
 
-        /** Update the camera if there's any speed */
+        /* Update the camera if there's any speed */
         if (this._azimuthSpeed !== 0 || this._polarSpeed !== 0) {
             this._updateCamera();
         }
@@ -146,22 +146,23 @@ export class OrbitalCamera extends Component {
      * @param rotation the rotation to get the closest position to
      */
     getClosestPosition(position: vec3, rotation: quat) {
-        // It's a bit hacky, but the easiest way to get the rotation of the camera is just briefly
-        // change the rotation to look at the center and then get the rotation.
+        /* It's a bit hacky, but the easiest way to get the rotation of the camera is just briefly
+         change the rotation to look at the center and then get the rotation. */
         this.object.getRotationWorld(tempquat);
         this.object.lookAt(this._origin);
         this.object.getRotationWorld(tempquat2);
 
         if (quat.dot(tempquat, tempquat2) < 0) {
-            quat.scale(tempquat2, tempquat2, -1); // Negate to ensure shortest path
+            quat.scale(tempquat2, tempquat2, -1); /* Negate to ensure shortest path */
         }
         this.object.setRotationWorld(tempquat);
 
-        // Calculate the direction from the center of orbit to the current camera position
+        /* Calculate the direction from the center of orbit to the current camera position */
         const directionToCamera = vec3.create();
         vec3.subtract(directionToCamera, position, this._origin as vec3);
         vec3.normalize(directionToCamera, directionToCamera);
-        // Scale this direction by the radius of your orbital sphere to get the nearest point on the sphere
+        
+        /* Scale this direction by the radius of your orbital sphere to get the nearest point on the sphere */
         const nearestPointOnSphere = vec3.create();
         vec3.scale(nearestPointOnSphere, directionToCamera, this.radial);
         vec3.add(nearestPointOnSphere, nearestPointOnSphere, this._origin as vec3);
@@ -176,15 +177,15 @@ export class OrbitalCamera extends Component {
     setPosition(cameraPosition: vec3) {
         const centerOfOrbit = this._origin as vec3;
 
-        // Compute the direction vector
+        /* Compute the direction vector */
         vec3.subtract(tempVec3, cameraPosition, centerOfOrbit);
         vec3.normalize(tempVec3, tempVec3);
-        // Compute the azimuth angle (in radians)
+        /* Compute the azimuth angle (in radians) */
         const azimuth = Math.atan2(tempVec3[0], tempVec3[2]);
-        // Compute the polar angle (in radians)
+        /* Compute the polar angle (in radians) */
         const polar = Math.acos(tempVec3[1]);
         const azimuthDeg = rad2deg(azimuth);
-        // Polar is inverted to match the orbital camera
+        /* Polar is inverted to match the orbital camera */
         const polarDeg = 90 - rad2deg(polar);
         this._azimuth = azimuthDeg;
         this._polar = polarDeg;
@@ -214,7 +215,7 @@ export class OrbitalCamera extends Component {
             this._mouseDown = true;
             document.body.style.cursor = 'grabbing';
             if (e.button === 1) {
-                e.preventDefault(); /** to prevent scrolling */
+                e.preventDefault(); /* to prevent scrolling */
                 return false;
             }
         }
@@ -237,7 +238,7 @@ export class OrbitalCamera extends Component {
     };
 
     private _onMouseScroll = (e: WheelEvent) => {
-        e.preventDefault(); /** to prevent scrolling */
+        e.preventDefault(); /* to prevent scrolling */
 
         this.radial *= 1 - e.deltaY * this.zoomSensitivity * -0.001;
         this.radial = Math.min(this.maxZoom, Math.max(this.minZoom, this.radial));
@@ -249,16 +250,16 @@ export class OrbitalCamera extends Component {
 
     private _onTouchStart = (e: TouchEvent) => {
         if (e.touches.length === 1) {
-            /** to prevent scrolling and allow us to track touch movement */
+            /* to prevent scrolling and allow us to track touch movement */
             e.preventDefault();
 
             this._touchStartX = e.touches[0].clientX;
             this._touchStartY = e.touches[0].clientY;
-            this._mouseDown = true; /** Treat touch like mouse down */
+            this._mouseDown = true; /* Treat touch like mouse down */
         } else if (e.touches.length === 2) {
-            /** Calculate initial pinch distance */
+            /* Calculate initial pinch distance */
             this._initialPinchDistance = this._getDistanceBetweenTouches(e.touches);
-            e.preventDefault(); /** Prevent default pinch actions */
+            e.preventDefault(); /* Prevent default pinch actions */
         }
     };
 
@@ -266,7 +267,7 @@ export class OrbitalCamera extends Component {
         if (!this.active || !this._mouseDown) {
             return;
         }
-        e.preventDefault(); /** to prevent moving the page */
+        e.preventDefault(); /* to prevent moving the page */
         if (e.touches.length === 1) {
             const deltaX = e.touches[0].clientX - this._touchStartX;
             const deltaY = e.touches[0].clientY - this._touchStartY;
@@ -277,7 +278,7 @@ export class OrbitalCamera extends Component {
             this._touchStartX = e.touches[0].clientX;
             this._touchStartY = e.touches[0].clientY;
         } else if (e.touches.length === 2) {
-            /** Handle pinch zoom */
+            /* Handle pinch zoom */
             const currentPinchDistance = this._getDistanceBetweenTouches(e.touches);
             const pinchScale = this._initialPinchDistance / currentPinchDistance;
 
@@ -286,17 +287,17 @@ export class OrbitalCamera extends Component {
 
             this._updateCamera();
 
-            /** Update initial pinch distance for next move */
+            /* Update initial pinch distance for next move */
             this._initialPinchDistance = currentPinchDistance;
         }
     };
 
     private _onTouchEnd = (e: TouchEvent) => {
         if (e.touches.length < 2) {
-            this._mouseDown = false; /** Treat touch end like mouse up */
+            this._mouseDown = false; /* Treat touch end like mouse up */
         }
         if (e.touches.length === 1) {
-            /** Prepare for possible single touch movement */
+            /* Prepare for possible single touch movement */
             this._touchStartX = e.touches[0].clientX;
             this._touchStartY = e.touches[0].clientY;
         }

--- a/orbital-camera.ts
+++ b/orbital-camera.ts
@@ -64,8 +64,11 @@ export class OrbitalCamera extends Component {
     private _azimuthSpeed: number = 0;
     private _polarSpeed: number = 0;
 
-    start(): void {
+    init() {
         this.object.getPositionWorld(this._origin);
+    }
+
+    start(): void {
         this._updateCamera();
     }
 
@@ -185,6 +188,7 @@ export class OrbitalCamera extends Component {
         const polarDeg = 90 - rad2deg(polar);
         this._azimuth = azimuthDeg;
         this._polar = polarDeg;
+        console.log(this._origin);
     }
 
     /**

--- a/orbital-camera.ts
+++ b/orbital-camera.ts
@@ -174,13 +174,12 @@ export class OrbitalCamera extends Component {
         const centerOfOrbit = this._origin as vec3;
 
         // Compute the direction vector
-        const direction = vec3.create();
-        vec3.subtract(direction, cameraPosition, centerOfOrbit);
-        vec3.normalize(direction, direction);
+        vec3.subtract(tempVec3, cameraPosition, centerOfOrbit);
+        vec3.normalize(tempVec3, tempVec3);
         // Compute the azimuth angle (in radians)
-        const azimuth = Math.atan2(direction[0], direction[2]);
+        const azimuth = Math.atan2(tempVec3[0], tempVec3[2]);
         // Compute the polar angle (in radians)
-        const polar = Math.acos(direction[1]);
+        const polar = Math.acos(tempVec3[1]);
         const azimuthDeg = rad2deg(azimuth);
         // Polar is inverted to match the orbital camera
         const polarDeg = 90 - rad2deg(polar);

--- a/orbital-camera.ts
+++ b/orbital-camera.ts
@@ -188,7 +188,6 @@ export class OrbitalCamera extends Component {
         const polarDeg = 90 - rad2deg(polar);
         this._azimuth = azimuthDeg;
         this._polar = polarDeg;
-        console.log(this._origin);
     }
 
     /**

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -57,3 +57,7 @@ export function setFirstMaterialTexture(
 export function deg2rad(value:number){
     return value * Math.PI / 180.0;
 }
+
+export function rad2deg(value: number) {
+    return (value * 180.0) / Math.PI;
+}


### PR DESCRIPTION
Add two methods to orbital camera:
- _getClosestPosition_. Gets a position and rotation (towards origin) based on a provided position on the orbit sphere of the camera.
- _setPosition_. Sets the position of the orbital camera on the sphere.

Fix issue where camera keeps moving if moving of mouse/touch stops.